### PR TITLE
Proposal for AdonisJS Governance

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -4,7 +4,7 @@
 
 ### Authors
 
-Harminder Virk (the creator of AdonisJS) serves as the Project Author. The project author is responsible for the project's governance, standards, and direction. To summarize.
+Harminder Virk (the creator of AdonisJS) serves as the Project Author. The project author is responsible for the project's governance, standards, and direction. To summarize:
 
 - The project author decides which new projects should live under the AdonisJS umbrella.
 - The project author is responsible for assigning leads to projects and transferring projects to a new lead when an existing lead steps down.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -82,7 +82,7 @@ If you run a business using the project as a revenue-generating product, it make
 
 AdonisJS (spelled with "JS" at the end) is a registered trademark of Harminder Virk.
 
-Only the projects under the `@adonisjs` npm scope and the AdonisJS Github organization are managed and officially supported by the core team.
+Only the projects under the `@adonisjs` npm scope and the AdonisJS GitHub organization are managed and officially supported by the core team.
 
 Also, you must not use the AdonisJS name or logos in a way that could mistakenly imply any official connection with or endorsement of AdonisJS. Any use of the AdonisJS name or logos in a manner that could cause customer confusion is not permitted.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -31,7 +31,7 @@ Core team members have no authority over the overall direction of the project. H
 
 #### Active Core Team Members
 
-Active Core Team Members contribute to the project on a regular basis. An active core team member usually have one or more focus area - in the most common cases, they will be responsible for the regular issue triaging, bug fixing, documentation improvements or feature development in a sub project repository.
+Active Core Team Members contribute to the project on a regular basis. An active core team member usually has or more focus areas - in the most common cases, they will be responsible for the regular issue triaging, bug fixing, documentation improvements or feature development in a subproject repository.
 
 #### Core Team Emeriti
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -14,7 +14,7 @@ Harminder Virk (the creator of AdonisJS) serves as the Project Author. The proje
 
 AdonisJS is a combination of several packages created and managed by the core team. All of these packages are led by a project lead selected by the project Author. 
 
-In almost every case, the creator of the project serves as the project lead since they are the ones who have put the initial efforts into bringing the idea to life.
+In almost every case, the creator of the package serves as the project lead since they are the ones who have put the initial efforts into bringing the idea to life.
 
 The project lead has the final say in all aspects of decision-making within the project. However, because the community always has the ability to fork, this person is fully answerable to the community. It is the project lead's responsibility to set the strategic objectives of the project and communicate these clearly to the community. They also have to understand the community as a whole and strive to satisfy as many conflicting needs as possible while ensuring that the project survives in the long term.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -94,7 +94,7 @@ Additionally, you may not use our trademarks for t-shirts, stickers, or other me
 
 ## Projects under AdonisJS umbrella
 
-Projects under the AdonisJS umbrella are the intellectual property of the Project Author. Once a project created by a project lead becomes part of the "AdonisJS Github organization," or if it is published under the `@adonisjs` npm scope, the project leads cannot delete or abandon the project.
+Projects under the AdonisJS umbrella are the intellectual property of the Project Author. Once a project created by a project lead becomes part of the "AdonisJS GitHub organization," or if it is published under the `@adonisjs` npm scope, the project leads cannot delete or abandon the project.
 
 ---
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -64,7 +64,7 @@ Users should be encouraged to participate in the life of the project and the com
 - Evangelizing about the project.
 - Informing developers of project strengths and weaknesses from a new user's perspective.
 - Providing moral support (a 'thank you' goes a long way).
-- Providing financial support through Github Sponsors.
+- Providing financial support through GitHub Sponsors.
 
 Users who continue to engage with the project and its community will often find themselves becoming more and more involved. Such users may then go on to become contributors, as described above.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,101 @@
+# Governance
+
+## Roles and responsibilities
+
+### Authors
+
+Harminder Virk (the creator of AdonisJS) serves as the Project Author. The project author is responsible for the project's governance, standards, and direction. To summarize.
+
+- The project author decides which new projects should live under the AdonisJS umbrella.
+- The project author is responsible for assigning leads to projects and transferring projects to a new lead when an existing lead steps down.
+- It is the author's responsibility to share/document the framework's vision and keep project leads in sync with the same.
+
+### Project Leads
+
+AdonisJS is a combination of several packages created and managed by the core team. All of these packages are led by a project lead selected by the project Author. 
+
+In almost every case, the creator of the project serves as the project lead since they are the ones who have put the initial efforts into bringing the idea to life.
+
+The project lead has the final say in all aspects of decision-making within the project. However, because the community always has the ability to fork, this person is fully answerable to the community. It is the project lead's responsibility to set the strategic objectives of the project and communicate these clearly to the community. They also have to understand the community as a whole and strive to satisfy as many conflicting needs as possible while ensuring that the project survives in the long term.
+
+In many ways, the role of the project lead is about diplomacy. The key is to ensure that, as the project expands, the right people are given influence over it, and the community rallies behind the vision of the project lead. The lead's job is then to ensure that the core team members (see below) make the right decisions on behalf of the project. Generally speaking, as long as the core team members are aligned with the project's strategy, the project lead will allow them to proceed as desired.
+
+> [!IMPORTANT]
+> A project lead cannot archive or decide to remove the project from the AdonisJS umbrella. They can decide to stop working on the project, and in that case, we will find a new project lead.
+
+### Core team
+
+Members of the core team are contributors who have made multiple valuable contributions to the project and are now relied upon to both write code directly to the repository and screen the contributions of others. In many cases, they are programmers, but it is also possible that they contribute in a different role, for example, community engagement. Typically, a core team member will focus on a specific aspect of the project and will bring a level of expertise and understanding that earns them the respect of the community and the project lead. The role of core team member is not an official one, it is simply a position that influential members of the community will find themselves in as the project lead looks to them for guidance and support.
+
+Core team members have no authority over the overall direction of the project. However, they do have the ear of the project lead. It is a core team member's job to ensure that the lead is aware of the community's needs and collective objectives, and to help develop or elicit appropriate contributions to the project. Often, core team members are given informal control over their specific areas of responsibility, and are assigned rights to directly modify certain areas of the source code. That is, although core team members do not have explicit decision-making authority, they will often find that their actions are synonymous with the decisions made by the lead.
+
+#### Active Core Team Members
+
+Active Core Team Members contribute to the project on a regular basis. An active core team member usually have one or more focus area - in the most common cases, they will be responsible for the regular issue triaging, bug fixing, documentation improvements or feature development in a sub project repository.
+
+#### Core Team Emeriti
+
+Some core team members who have made valuable contributions in the past may no longer be able to commit to the same level of participation today due to various reasons. That is perfectly normal, and any past contributions to the project are still highly appreciated. These core team members are honored for their contributions as Core Team Emeriti, and are welcome to resume active participation at any time.
+
+### Contributors
+
+Contributors are community members who either have no desire to become core team members, or have not yet been given the opportunity by the project lead. They make valuable contributions, such as those outlined in the list below, but generally do not have the authority to make direct changes to the project code. Contributors engage with the project through communication tools, such as the RFC discussions, GitHub issues and pull requests, Discord chatroom, and the forum.
+
+Anyone can become a contributor. There is no expectation of commitment to the project, no specific skill requirements and no selection process. To become a contributor, a community member simply has to perform one or more actions that are beneficial to the project.
+
+Some contributors will already be engaging with the project as users, but will also find themselves doing one or more of the following:
+
+- Supporting new users (current users often provide the most effective new user support)
+- Reporting bugs
+- Identifying requirements
+- Programming
+- Assisting with project infrastructure
+- Fixing bugs
+- Adding features
+
+As contributors gain experience and familiarity with the project, they may find that the project lead starts relying on them more and more. When this begins to happen, they gradually adopt the role of core team member, as described above.
+
+### Users
+
+Users are community members who have a need for the project. They are the most important members of the community: without them, the project would have no purpose. Anyone can be a user; there are no specific requirements.
+
+Users should be encouraged to participate in the life of the project and the community as much as possible. User contributions enable the project team to ensure that they are satisfying the needs of those users. Common user activities include (but are not limited to):
+
+- Evangelizing about the project.
+- Informing developers of project strengths and weaknesses from a new user's perspective.
+- Providing moral support (a 'thank you' goes a long way).
+- Providing financial support through Github Sponsors.
+
+Users who continue to engage with the project and its community will often find themselves becoming more and more involved. Such users may then go on to become contributors, as described above.
+
+## Support
+
+All participants in the community are encouraged to provide support for new users within the project management infrastructure. This support is provided as a way of growing the community. Those seeking support should recognize that all support activity within the project is voluntary and is therefore provided as and when time allows. A user requiring guaranteed response times or results should therefore seek to purchase a support contract. However, for those willing to engage with the project on its terms, and willing to help support other users, the community support channels are ideal.
+
+### Monetary Donations
+
+For an open development project, money is less important than active contribution. However, some people or organizations are cash-rich and time-poor and would prefer to make their contribution in the form of cash. If you want to make a significant donation, you may be able to sponsor us to implement a new feature or fix some bugs. The project website provides clear guidance on how to go about donating.
+
+If you run a business using the project as a revenue-generating product, it makes business sense to sponsor its development. It ensures the project that your product relies on stays healthy and actively maintained. It can also improve exposure in our community and make it easier to attract new developers.
+
+## Branding and Ownership
+
+AdonisJS (spelled with "JS" at the end) is a registered trademark of Harminder Virk.
+
+Only the projects under the `@adonisjs` npm scope and the AdonisJS Github organization are managed and officially supported by the core team.
+
+Also, you must not use the AdonisJS name or logos in a way that could mistakenly imply any official connection with or endorsement of AdonisJS. Any use of the AdonisJS name or logos in a manner that could cause customer confusion is not permitted.
+
+This includes naming a product or service in a way that emphasizes the AdonisJS brand, like "AdonisJS UIKit" or "AdonisJS Studio", as well as in domain names like "adonisjs-studio.com".
+
+Instead, you must use your own brand name in a way that clearly distinguishes it from AdonisJS.
+
+Additionally, you may not use our trademarks for t-shirts, stickers, or other merchandise without explicit written consent.
+
+## Projects under AdonisJS umbrella
+
+Projects under the AdonisJS umbrella are the intellectual property of the Project Author. Once a project created by a project lead becomes part of the "AdonisJS Github organization," or if it is published under the `@adonisjs` npm scope, the project leads cannot delete or abandon the project.
+
+---
+
+> This governance document is based upon the [Benevolent Dictator Governance Model](http://oss-watch.ac.uk/resources/benevolentdictatorgovernancemodel) by Ross Gardler and Gabriel Hanganu, licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License](https://creativecommons.org/licenses/by-sa/4.0/). This document itself is also licensed under the same license.


### PR DESCRIPTION
The governance model is built around the physical reality of our setup, and some inspiration is taken from the following projects.

Apart from the following projects, I also looked at TailwindCSS, FilamentPhp, TanStack, and Hono, but they have not publicly published any formal governance model.

- **Laravel** - No formal governance model. I assume Laravel (the company) is in charge of making decisions. However, they have a contributing guide, which briefly [talks about the "Core development discussions" process](https://laravel.com/docs/10.x/contributions#core-development-discussion).
- **VueJS** - Our setup is closer to VueJS, where VueJS is created and maintained mainly by a single individual but with the help of contributors. They also have a core team, + many individuals have built an ecosystem around VueJS. [Link to Governance model](https://github.com/vuejs/governance/blob/master/Governance-Document.md).
- **Nuxt JS** - NuxtJS partially resembles with our setup. In Nuxt's case, the project is led by the Chopin brothers and the core team. However, they have specific individuals who act as leads for other in-house projects. [Link to Governance model](https://github.com/nuxt/governance)

---

The "Decision making process" is not yet documented. For that, I will submit another proposal titled "How we work" and abstract the decision making process from it.