### PR TITLE
Fix documentation links in README.md

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -8,11 +8,11 @@ Following are some hand-picked features from the framework core and first party 
 
 - [HTTP layer](https://docs.adonisjs.com/guides/concepts/http-overview#the-http-layer) with support for **routing**, **middleware**, **session**, **secure cookies**, and a lot more.
 - Support for [file uploads](https://docs.adonisjs.com/guides/file-uploads).
-- [Filesystem drive](https://docs.adonisjs.com/guides/drive) to move user uploaded files to cloud services like S3, GCS and Digital ocean.
-- [Schema validator](https://docs.adonisjs.com/guides/validator/introduction) to validate forms.
-- [Template engine](https://docs.adonisjs.com/guides/views/introduction) to create traditional server render applications in no time.
+- [Filesystem drive](https://docs.adonisjs.com/guides/digging-deeper/drive) to move user uploaded files to cloud services like S3, GCS and Digital ocean.
+- [Schema validator](https://docs.adonisjs.com/guides/basics/validation) to validate forms.
+- [Template engine](https://docs.adonisjs.com/guides/views-and-templates/introduction) to create traditional server render applications in no time.
 - [SQL ORM](https://docs.adonisjs.com/guides/sql) built on top of Active record.
-- A fully featured [authentication layer](https://docs.adonisjs.com/guides/auth/introduction) with support for **sessions**, **api tokens**, and **social auth**.
+- A fully featured [authentication layer](https://docs.adonisjs.com/guides/authentication/introduction) with support for **sessions**, **api tokens**, and **social auth**.
 - Baked-in support for [testing](https://docs.adonisjs.com/guides/testing/introduction)
 - We have just scratched the surface. AdonisJS has a lot more that you usually need when building robust applications.
 


### PR DESCRIPTION
Updated links in the README to point to the correct documentation pages.

<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue
#9 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Repairing the link will allow you to link to the correct document.
It fix #9 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
